### PR TITLE
Added API functions to service.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/*
 bin/*
 .DS_Store
 .idea
+**.remote-sync.json

--- a/src/Silex/ckan/CkanClient.php
+++ b/src/Silex/ckan/CkanClient.php
@@ -7,7 +7,7 @@ use Guzzle\Common\Collection;
 use Guzzle\Service\Client;
 use Guzzle\Service\Description\ServiceDescription;
 
-class CkanClient extends Client {	
+class CkanClient extends Client {
 
     /**
      * Factory method to create a new CkanClient

--- a/src/Silex/ckan/service.json
+++ b/src/Silex/ckan/service.json
@@ -36,7 +36,7 @@
         },
         "GetDataset": {
             "httpMethod": "GET",
-            "uri": "3/action/package_show?id={id}",
+            "uri": "3/action/package_show?id={id}&use_default_schema={use_default_schema}",
             "summary": "Retrieves a dataset",
             "responseClass": "GetDatasetOutput",
             "parameters": {
@@ -44,6 +44,11 @@
                     "location": "uri",
                     "description": "Dataset reference to retrieve",
                     "required": true
+                },
+                "use_default_schema": {
+                  "location": "uri",
+                  "description": "use default package schema instead of a custom schema defined with an IDatasetForm plugin (default: False)",
+                  "required": false
                 }
             }
         },
@@ -158,6 +163,11 @@
                     "location": "query",
                     "description": "The facet query passed to SoLR.",
                     "required": false
+                },
+                "rows": {
+                  "location": "query",
+                  "description": "The number of matching rows to return.",
+                  "required": false
                 }
             }
         },

--- a/src/Silex/ckan/service.json
+++ b/src/Silex/ckan/service.json
@@ -20,13 +20,13 @@
           "httpMethod": "GET",
           "uri": "3/action/status_show",
           "summary": "Return a dictionary with information about the site’s configuration.",
-          "responseClass": "StatusShowOutput"
+          "responseClass": "CkanApiOutput"
         },
         "SiteRead": {
           "httpMethod": "GET",
           "uri": "3/action/site_read",
           "summary": "Kind of ping function",
-          "responseClass": "SiteReadOutput"
+          "responseClass": "CkanApiOutput"
         },
         "GetDatasets": {
             "httpMethod": "GET",
@@ -64,6 +64,25 @@
                     "required": true
                 }
             }
+        },
+        "GetOrganizationsUserIsMemberOf": {
+          "httpMethod": "GET",
+          "uri": "3/action/organization_list_for_user?permission={permission}",
+          "summary": "Retrieves a user",
+          "responseClass": "CkanApiOutput",
+          "parameters": {
+            "permission": {
+              "location": "uri",
+              "description": "(String) the permission the user has against the returned organizations, for example 'read' or 'create_dataset'",
+              "required": false
+            }
+          }
+        },
+        "GetGroupsUserCanEdit": {
+          "httpMethod": "GET",
+          "uri": "3/action/group_list_authz",
+          "summary": "Retrieves a user",
+          "responseClass": "CkanApiOutput"
         },
         "GetDatasetCount": {
             "httpMethod": "GET",

--- a/src/Silex/ckan/service.json
+++ b/src/Silex/ckan/service.json
@@ -55,9 +55,16 @@
         },
         "GetGroups": {
             "httpMethod": "GET",
-            "uri": "3/action/organization_list",
+            "uri": "3/action/organization_list?all_fields={all_fields}",
             "summary": "Retrieves a list of groups",
-            "responseClass": "GetGroupsOutput"
+            "responseClass": "GetGroupsOutput",
+            "parameters": {
+              "all_fields": {
+                "location": "uri",
+                "description": "(boolean) – return group dictionaries instead of just names. Only core fields are returned - get some more using the include_* options. Returning a list of packages is too expensive, so the packages property for each group is deprecated, but there is a count of the packages in the package_count property. (optional, default: False)",
+                "required": false
+              }
+            }
         },
         "GetGroup": {
             "httpMethod": "GET",
@@ -146,6 +153,24 @@
                     "sentAs" : "Content-Type"
                 }
             }
+        },
+        "PackageUpdate": {
+          "httpMethod": "POST",
+          "uri": "action/package_update?id={id}",
+          "summary": "Update a dataset (package).",
+          "responseClass": "CkanApiOutput",
+          "parameters": {
+            "data": {
+              "location": "body"
+            },
+            "content-type": {
+              "location": "header",
+              "static": true,
+              "required" : true,
+              "default" : "application/json",
+              "sentAs" : "Content-Type"
+            }
+          }
         },
         "PackageDelete": {
             "httpMethod": "POST",
@@ -301,7 +326,7 @@
                 }
             }
         },
- 	    "GetRevisionsOutput": {
+       "GetRevisionsOutput": {
             "type": "object",
             "properties": {
                 "id": {

--- a/src/Silex/ckan/service.json
+++ b/src/Silex/ckan/service.json
@@ -185,7 +185,12 @@
                 },
                 "rows": {
                   "location": "query",
-                  "description": "The number of matching rows to return.",
+                  "description": "(int) The number of matching rows to return.",
+                  "required": false
+                },
+                "start": {
+                  "location": "query",
+                  "description": "(int) The offset in the complete result for where the set of returned datasets should begin.",
                   "required": false
                 }
             }

--- a/src/Silex/ckan/service.json
+++ b/src/Silex/ckan/service.json
@@ -16,6 +16,18 @@
                 }
             }
         },
+        "StatusShow": {
+          "httpMethod": "GET",
+          "uri": "3/action/status_show",
+          "summary": "Return a dictionary with information about the site’s configuration.",
+          "responseClass": "StatusShowOutput"
+        },
+        "SiteRead": {
+          "httpMethod": "GET",
+          "uri": "3/action/site_read",
+          "summary": "Kind of ping function",
+          "responseClass": "SiteReadOutput"
+        },
         "GetDatasets": {
             "httpMethod": "GET",
             "uri": "3/action/package_list",
@@ -53,11 +65,11 @@
             "uri": "util/dataset-count",
             "summary": "Retrieves total number of datasets."
         },
-        "GetGroups": {
+        "GetOrganizations": {
             "httpMethod": "GET",
             "uri": "3/action/organization_list?all_fields={all_fields}",
-            "summary": "Retrieves a list of groups",
-            "responseClass": "GetGroupsOutput",
+            "summary": "Retrieves a list of organizations",
+            "responseClass": "GetOrganizationsOutput",
             "parameters": {
               "all_fields": {
                 "location": "uri",
@@ -65,6 +77,19 @@
                 "required": false
               }
             }
+        },
+        "GetGroups": {
+          "httpMethod": "GET",
+          "uri": "3/action/group_list?all_fields={all_fields}",
+          "summary": "Retrieves a list of groups",
+          "responseClass": "GetGroupsOutput",
+          "parameters": {
+            "all_fields": {
+              "location": "uri",
+              "description": "(boolean) – return group dictionaries instead of just names. Only core fields are returned - get some more using the include_* options. Returning a list of packages is too expensive, so the packages property for each group is deprecated, but there is a count of the packages in the package_count property. (optional, default: False)",
+              "required": false
+            }
+          }
         },
         "GetGroup": {
             "httpMethod": "GET",
@@ -242,6 +267,12 @@
     },
 
     "models": {
+        "StatusShowOutput": {
+          "type": "dictionary"
+        },
+        "SiteReadOutput": {
+          "type": "boolean"
+        },
         "PublisherShowOutput": {
             "type": "object",
             "properties": {
@@ -315,7 +346,6 @@
                 }
             }
         },
-
         "GetGroupsOutput": {
             "type": "object",
             "properties": {
@@ -325,6 +355,16 @@
                     "type": "string"
                 }
             }
+        },
+        "GetOrganizationsOutput": {
+          "type": "object",
+          "properties": {
+            "groups": {
+              "description": "List of all organizations on CKAN",
+              "location": "json",
+              "type": "string"
+            }
+          }
         },
        "GetRevisionsOutput": {
             "type": "object",


### PR DESCRIPTION
While using CKAN_PHP for https://github.com/OpenDevelopmentMekong/wpckan, i have extended the functions available in service.json and added new ones in order to implement a series of calls that the project needed:
- GetGroups: Added "all_fields" parameter
- Added StatusShow
- Added "rows" parameter on package_search
- Added GetOrganizationsUserIsMemberOf and GetGroupsUserCanEdit methods
